### PR TITLE
Convert install.py to handle relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ old_versions
 data
 pythoninterpreter.py
 *.tar
+.vscode/settings.json

--- a/install.py
+++ b/install.py
@@ -3,10 +3,7 @@
 import os
 import sys
 
-
-path = os.path.dirname(os.path.realpath(__file__)) # current path
-sys.path.append(path+"/pysrc/") # add the interpreter
-from interpreter import pycommand
+from pysrc.interpreter import pycommand
 
 pycommand.install_python() # install the correct python dist
 pycommand.install_dependencies() # install the dependencies


### PR DESCRIPTION
Python can easily handle relative paths, rather than needing to absolute path everything. This will enable installation on Windows and easier debugging. This should not affect Linux/Mac installs negatively.