### PR TITLE
Fixes - Parallel errors, extension for Windows, import errors, path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ old_versions
 data
 pythoninterpreter.py
 *.tar
-.vscode/settings.json
+.vscode
+tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ old_versions
 data
 pythoninterpreter.py
 *.tar
+.vscode/settings.json

--- a/bin/quantum-honeycomp.py
+++ b/bin/quantum-honeycomp.py
@@ -1,51 +1,55 @@
 import os
 import sys
 import platform
-
-
-
 import argparse
+import subprocess
+from pathlib import Path
+
+
 parser = argparse.ArgumentParser()
-parser.add_argument("--utility",default="",
-        help='Just use an utility and exit')
-parser.add_argument("--python",default="",
-        help='Default Python interpreter')
-args = parser.parse_args() # get the arguments
-
-
+parser.add_argument("--utility", default="",
+                    help='Just use a utility and exit')
+parser.add_argument("--python", default="",
+                    help='Default Python interpreter')
+args = parser.parse_args()  # get the arguments
 
 
 def get_qhroot():
-  """Gets the root path of quantum honeycomp"""
-  return os.path.dirname(os.path.dirname(os.path.realpath(__file__))) 
-  #return os.path.dirname(os.path.realpath(__file__))+"/../" 
+    """Gets the root path of quantum honeycomp"""
+    return Path(__file__).resolve().parent.parent
+
 
 qhroot = get_qhroot()  # get the root path
-os.environ["QHROOT"] = qhroot # create the environmental variable
+os.environ["QHROOT"] = str(qhroot)  # create the environmental variable
 
 
 def get_command(name="python"):
-  """Return the path for Anaconda Python, which has pyqt by default"""
-  dirname = os.path.dirname(os.path.realpath(__file__))
-  sys.path.append(dirname+"/../pysrc/") # add this path
-  from interpreter import pycommand
-  return pycommand.get_python()
+    """Return the path for Anaconda Python, which has pyqt by default"""
+    #dirname = os.path.dirname(os.path.realpath(__file__))
+    qhroot = get_qhroot()
+    path = qhroot.joinpath("pysrc", "interpreter")
+    sys.path.insert(1, str(path))  # add this path
+    print("Path: ", str(path))
+    import pycommand
+    return pycommand.get_python()
 
 
 python = get_command()
 
 
-if args.python!="": # non empty string
-    f = open(qhroot+"/pysrc/interpreter/pythoninterpreter.py","w")
-    f.write("mainpython = \""+args.python+"\"\n")
-    f.close()
+if args.python != "":  # non empty string
+    path = qhroot.joinpath("pysrc", "interpreter", "pythoninterpreter.py")
+    with open(path, mode='wt') as config:
+        config.write("mainpython = r\""+args.python+"\"\n")    
 
 
+# Use a utility and exit
+if args.utility != "":  # non empty string
+    utility = qhroot.joinpath('utilities')
+    subprocess.run(["python", str(utility), args.utility])
+    #os.system(python + " "+qhroot+"/utilities/"+args.utility)
+    exit()
 
-# use an utility and exit
-if args.utility!="": # non empty string
-  os.system(python + " "+qhroot+"/utilities/"+args.utility)
-  exit()
 
-
-os.system(python+" "+qhroot+"/bin/versions/quantum-honeycomp-pyqt")
+pyqt = qhroot.joinpath('bin', "versions", "quantum-honeycomp-pyqt")
+subprocess.run(["python", str(pyqt)])

--- a/bin/quantum-honeycomp.py
+++ b/bin/quantum-honeycomp.py
@@ -17,7 +17,8 @@ args = parser.parse_args() # get the arguments
 
 def get_qhroot():
   """Gets the root path of quantum honeycomp"""
-  return os.path.dirname(os.path.realpath(__file__))+"/../" 
+  return os.path.dirname(os.path.dirname(os.path.realpath(__file__))) 
+  #return os.path.dirname(os.path.realpath(__file__))+"/../" 
 
 qhroot = get_qhroot()  # get the root path
 os.environ["QHROOT"] = qhroot # create the environmental variable
@@ -47,4 +48,4 @@ if args.utility!="": # non empty string
   exit()
 
 
-os.system(python+" "+qhroot+"bin/versions/quantum-honeycomp-pyqt")
+os.system(python+" "+qhroot+"/bin/versions/quantum-honeycomp-pyqt")

--- a/bin/versions/quantum-honeycomp-pyqt
+++ b/bin/versions/quantum-honeycomp-pyqt
@@ -3,6 +3,7 @@
 import sys
 import os
 import platform
+from pathlib import Path
 
   
 # Add path of the interface

--- a/pysrc/interfacetk/common.py
+++ b/pysrc/interfacetk/common.py
@@ -4,198 +4,206 @@ from pygra import klist
 from .qh_interface import *
 from pygra import parallel
 
-def get_operator(h,opname,projector=False):
+
+def get_operator(h, opname, projector=False):
     """Return an operator"""
-    if opname=="None": op = None # no operators
-    elif opname=="Sx": op = h.get_operator("sx") # off plane case
-    elif opname=="Berry": op = h.get_operator("berry") # off plane case
-    elif opname=="Sy": op = h.get_operator("sy")# off plane case
-    elif opname=="Sz": op = h.get_operator("sz")# off plane case
-    elif opname=="Valley": op = h.get_operator("valley",projector=projector)
-    elif opname=="IPR": op = h.get_operator("ipr")
-    elif opname=="y-position": op = h.get_operator("yposition")
-    elif opname=="x-position": op = h.get_operator("xposition")
-    elif opname=="z-position": op = h.get_operator("zposition")
-    elif opname=="Interface": op = h.get_operator("interface")
-    elif opname=="Surface": op = h.get_operator("surface")
-    elif opname=="Layer": op = h.get_operator("zposition")
-    else: op = h.get_operator(opname)
+    if opname == "None":
+        op = None  # no operators
+    elif opname == "Sx":
+        op = h.get_operator("sx")  # off plane case
+    elif opname == "Berry":
+        op = h.get_operator("berry")  # off plane case
+    elif opname == "Sy":
+        op = h.get_operator("sy")  # off plane case
+    elif opname == "Sz":
+        op = h.get_operator("sz")  # off plane case
+    elif opname == "Valley":
+        op = h.get_operator("valley", projector=projector)
+    elif opname == "IPR":
+        op = h.get_operator("ipr")
+    elif opname == "y-position":
+        op = h.get_operator("yposition")
+    elif opname == "x-position":
+        op = h.get_operator("xposition")
+    elif opname == "z-position":
+        op = h.get_operator("zposition")
+    elif opname == "Interface":
+        op = h.get_operator("interface")
+    elif opname == "Surface":
+        op = h.get_operator("surface")
+    elif opname == "Layer":
+        op = h.get_operator("zposition")
+    else:
+        op = h.get_operator(opname)
     return op
 
 
-
-def get_bands(h,window):
+def get_bands(h, window):
     """Compute the bandstructure of the system"""
     opname = window.getbox("bands_color")
-    op = get_operator(h,opname) # get operator
-    kpath = klist.default(h.geometry,nk=int(window.get("nk_bands")))
+    op = get_operator(h, opname)  # get operator
+    kpath = klist.default(h.geometry, nk=int(window.get("nk_bands")))
     num_bands = int(window.get("nbands"))
-    if num_bands<1: num_bands = None # all the eigenvalues
-    check_parallel(window) # check if use parallelization
-    h.get_bands(operator=op,kpath=kpath,num_bands=num_bands)
-    command = "qh-bands --dim "+str(h.dimensionality) 
-    if op is not None: command += " --cblabel "+opname
-#    if window.getbox("bands_colormap") is not None: 
+    if num_bands < 1:
+        num_bands = None  # all the eigenvalues
+    check_parallel(window)  # check if use parallelization
+    h.get_bands(operator=op, kpath=kpath, num_bands=num_bands)
+    command = "qh-bands --dim "+str(h.dimensionality)
+    if op is not None:
+        command += " --cblabel "+opname
+#    if window.getbox("bands_colormap") is not None:
 #        command += " --cmap "+window.getbox("bands_colormap")
-    execute_script(command) # execute the command
+    execute_script(command)  # execute the command
 
 
-
-
-def get_kdos(h,window):
+def get_kdos(h, window):
     """Show the KDOS"""
     ew = window.get("kdos_ewindow")
-    new = int(window.get("kdos_mesh")) # scale as kpoints
-    energies = np.linspace(-ew,ew,new) # number of ene
-    kpath = [[i,0.,0.] for i in np.linspace(0.,1.,new)]
-    kdos.surface(h,energies=energies,delta=ew/new,kpath=kpath)
+    new = int(window.get("kdos_mesh"))  # scale as kpoints
+    energies = np.linspace(-ew, ew, new)  # number of ene
+    kpath = [[i, 0., 0.] for i in np.linspace(0., 1., new)]
+    kdos.surface(h, energies=energies, delta=ew/new, kpath=kpath)
     command = "qh-kdos-both --input KDOS.OUT"
-    execute_script(command) # execute the script
+    execute_script(command)  # execute the script
 
 
-
-def show_exchange(h,window):
+def show_exchange(h, window):
     """Show the exchange field"""
-    nrep = max([int(window.get("magnetization_nrep")),1]) # replicas
-    h.write_magnetization(nrep=nrep) # write the magnetism
-    execute_script("qh-moments",mayavi=True)
+    nrep = max([int(window.get("magnetization_nrep")), 1])  # replicas
+    h.write_magnetization(nrep=nrep)  # write the magnetism
+    execute_script("qh-moments", mayavi=True)
 
 
-def get_dos(h,window,silent=False):
-  nk = max([int(window.get("dos_nk")),1])
-  delta = window.get("dos_delta")
-  ewindow = abs(window.get("dos_ewindow"))
-  energies = np.linspace(-ewindow,ewindow,int(ewindow/delta*5)) # get the energies
-  if window.getbox("dos_mode")=="Green":
-    dos.dos(h,delta=delta,nk=nk,energies=energies,mode="Green") # compute DOS
-  else:
-    dos.dos(h,delta=delta,nk=nk,energies=energies) # compute DOS
-  if not silent: execute_script("qh-dos --input DOS.OUT")
+def get_dos(h, window, silent=False):
+    nk = max([int(window.get("dos_nk")), 1])
+    delta = window.get("dos_delta")
+    ewindow = abs(window.get("dos_ewindow"))
+    energies = np.linspace(-ewindow, ewindow,
+                           int(ewindow/delta*5))  # get the energies
+    if window.getbox("dos_mode") == "Green":
+        dos.dos(h, delta=delta, nk=nk, energies=energies,
+                mode="Green")  # compute DOS
+    else:
+        dos.dos(h, delta=delta, nk=nk, energies=energies)  # compute DOS
+    if not silent:
+        execute_script("qh-dos --input DOS.OUT")
 
 
-
-def get_berry1d(h,window):
+def get_berry1d(h, window):
     """Get the one dimensional Berry curvature"""
     ks = klist.default(h.geometry,
-            nk=int(window.get("topology_nk")))  # write klist
+                       nk=int(window.get("topology_nk")))  # write klist
     opname = window.getbox("topology_operator")
-    op = get_operator(h,opname,projector=True) # get operator
-    topology.write_berry(h,ks,operator=op)
-    command = "qh-berry1d  --label True " 
-    if opname!="None": command += " --mode "+opname
+    op = get_operator(h, opname, projector=True)  # get operator
+    topology.write_berry(h, ks, operator=op)
+    command = "qh-berry1d  --label True "
+    if opname != "None":
+        command += " --mode "+opname
     execute_script(command)
 
 
-
-
-
-def get_berry2d(h,window):
+def get_berry2d(h, window):
     """Get the Berry curvature"""
     nk = int(np.sqrt(window.get("topology_nk")))
     opname = window.getbox("topology_operator")
-    op = get_operator(h,opname,projector=True) # get operator
-    topology.berry_map(h,nk=nk,operator=op)
+    op = get_operator(h, opname, projector=True)  # get operator
+    topology.berry_map(h, nk=nk, operator=op)
     execute_script("qh-berry2d BERRY_MAP.OUT")
 
 
-def get_chern(h,window):
+def get_chern(h, window):
     """Get the Chern number"""
     nk = int(np.sqrt(window.get("topology_nk")))
     opname = window.getbox("topology_operator")
-    op = get_operator(h,opname,projector=True) # get operator
-    topology.chern(h,nk=nk,operator=op)
+    op = get_operator(h, opname, projector=True)  # get operator
+    topology.chern(h, nk=nk, operator=op)
     execute_script("qh-chern BERRY_CURVATURE.OUT")
 
-def get_fermi_surface(h,window):
-    check_parallel(window) # check if use parallelization
+
+def get_fermi_surface(h, window):
+    check_parallel(window)  # check if use parallelization
     e = window.get("fs_ewindow")
-    energies = np.linspace(-e,e,100)
-    nk = int(window.get("fs_nk")) # number of kpoints
-    numw = int(window.get("fs_numw")) # number of waves for sparse
+    energies = np.linspace(-e, e, 100)
+    nk = int(window.get("fs_nk"))  # number of kpoints
+    numw = int(window.get("fs_numw"))  # number of waves for sparse
     delta = window.get("fs_delta")
-    spectrum.multi_fermi_surface(h,nk=nk,energies=energies,
-        delta=delta,nsuper=1,numw=numw)
+    spectrum.multi_fermi_surface(h, nk=nk, energies=energies,
+                                 delta=delta, nsuper=1, numw=numw)
     execute_script("qh-multifermisurface")
 
 
-
-def solve_scf(h,window):
-  """Perform a selfconsistent calculation"""
-  get = window.get # redefine
+def solve_scf(h, window):
+    """Perform a selfconsistent calculation"""
+    get = window.get  # redefine
 #  comp = computing() # create the computing window
-  scfin = window.getbox("scf_initialization")
-  mf = scftypes.guess(h,mode=scfin)
-  nk = int(get("nk_scf"))
-  U = get("U")
-  V1 = get("V1")
-  V2 = get("V2")
-  filling = get("filling_scf")
-  filling = filling%1. # filling
-  extrae = get("extra_electron")
-  filling += extrae/h.intra.shape[0] # extra electron
-  scf = meanfield.Vinteraction(h,nk=nk,filling=filling,U=U,V1=V1,V2=V2,
-                mf=mf,load_mf=False,#T=get("smearing_scf"),
-                mix = get("mix_scf"))
-  scf.hamiltonian.save() # save in a file
+    scfin = window.getbox("scf_initialization")
+    mf = scftypes.guess(h, mode=scfin)
+    nk = int(get("nk_scf"))
+    U = get("U")
+    V1 = get("V1")
+    V2 = get("V2")
+    filling = get("filling_scf")
+    filling = filling % 1.  # filling
+    extrae = get("extra_electron")
+    filling += extrae/h.intra.shape[0]  # extra electron
+    scf = meanfield.Vinteraction(h, nk=nk, filling=filling, U=U, V1=V1, V2=V2,
+                                 # T=get("smearing_scf"),
+                                 mf=mf, load_mf=False,
+                                 mix=get("mix_scf"))
+    scf.hamiltonian.save()  # save in a file
 #  comp.kill()
 
 
-
-def get_z2(h,window):
+def get_z2(h, window):
     nk = int(np.sqrt(window.get("topology_nk")))
-    topology.z2_vanderbilt(h,nk=nk,nt=nk//2) # calculate z2 invariant
-    execute_script("qh-wannier-center  ") # plot the result
+    topology.z2_vanderbilt(h, nk=nk, nt=nk//2)  # calculate z2 invariant
+    execute_script("qh-wannier-center  ")  # plot the result
 
 
-
-def get_multildos(h,window):
-    check_parallel(window) # check if use parallelization
+def get_multildos(h, window):
+    check_parallel(window)  # check if use parallelization
     ewin = window.get("multildos_ewindow")
-    nrep = int(max([1,window.get("multildos_nrep")]))
-    nk = int(max([1,window.get("multildos_nk")]))
+    nrep = int(max([1, window.get("multildos_nrep")]))
+    nk = int(max([1, window.get("multildos_nk")]))
     numw = int(window.get("multildos_numw"))
-    ne = 100 # 100 points
+    ne = 100  # 100 points
     delta = window.get("multildos_delta")
     proj = window.getbox("basis_ldos")
-    if proj=="Real space atomic orbitals":  projection = "atomic"
-    else: projection = "TB" # default one
-    ldos.multi_ldos(h,es=np.linspace(-ewin,ewin,ne),
-            nk=nk,delta=delta,nrep=nrep,numw=numw,
-            projection=projection,ratomic=window.get("ratomic_ldos"))
-    if projection=="TB": execute_script("qh-multildos ")
-    else: execute_script("qh-multildos --grid True")
-
-
-
-
-
+    if proj == "Real space atomic orbitals":
+        projection = "atomic"
+    else:
+        projection = "TB"  # default one
+    ldos.multi_ldos(h, es=np.linspace(-ewin, ewin, ne),
+                    nk=nk, delta=delta, nrep=nrep, numw=numw,
+                    projection=projection, ratomic=window.get("ratomic_ldos"))
+    if projection == "TB":
+        execute_script("qh-multildos ")
+    else:
+        execute_script("qh-multildos --grid True")
 
 
 def check_parallel(qtwrap):
-  """Check if there is parallelization"""
-  if qtwrap.getbox("use_parallelization") =="Yes":
-      parallel.cores = parallel.maxcpu
-  else: parallel.cores = 1 # single core
+    """Check if there is parallelization"""
+    if qtwrap.getbox("use_parallelization") == "Yes":
+        parallel.cores = parallel.maxcpu
+    else:
+        parallel.cores = 1  # single core
 
 
-
-def set_colormaps(form,name,cs=[]):
+def set_colormaps(form, name, cs=[]):
     """Add the different colormaps to a combox"""
-    try: cb = getattr(form,name)
+    try:
+        cb = getattr(form, name)
     except:
-        print("Combobox",name,"not found")
+        print("Combobox", name, "not found")
         return
-    cb.clear() # clear the items
+    cb.clear()  # clear the items
     cb.addItems(cs)
-
 
 
 def initialize(window):
     """Do various initializations"""
-    cs = ["RGB","hot","inferno","plasma","bwr","rainbow","gnuplot"]
-    set_colormaps(window.form,"bands_colormap",cs=cs) # set the bands
-    window.set_combobox("scf_initialization",meanfield.spinful_guesses)
-    window.set_combobox("bands_color",operators.operator_list)
-
-
-
+    cs = ["RGB", "hot", "inferno", "plasma", "bwr", "rainbow", "gnuplot"]
+    set_colormaps(window.form, "bands_colormap", cs=cs)  # set the bands
+    window.set_combobox("scf_initialization", meanfield.spinful_guesses)
+    window.set_combobox("bands_color", operators.operator_list)

--- a/pysrc/interfacetk/qh_interface.py
+++ b/pysrc/interfacetk/qh_interface.py
@@ -35,33 +35,27 @@ from pygra import timeevolution
 from pygra import embedding
 
 import platform
-
+import pathlib
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(dirname+"/../interpreter") # add this path
 from interpreter import pycommand
-
 
 def get_python():
   return pycommand.get_python()
 
 get_anaconda_command = get_python
 
-
-
-
-
-
-
 def get_qhroot():
   """Gets the root path of quantum honeycomp"""
   return os.path.dirname(os.path.realpath(__file__))+"/../../"
 
-
-
 def create_folder():
-  """Creates a temporal folder and goes to that one"""
-  os.chdir("/tmp")
+  """Creates a temporary folder in the tmp directory on *nix and goes to that one"""
+  """Workaround is to create a temporary directory locally. Keeps the files, but will need to clean up after a while."""
+  #dirname = os.path.dirname(os.path.realpath(__file__))
+  pathlib.Path("tmp").mkdir(parents=True, exist_ok=True)
+  os.chdir("tmp")
   # get the name of the folder
   i = 0
   forig = "qh-tmp-"
@@ -71,7 +65,8 @@ def create_folder():
     if not folder in folders:
       break # stop if folder doesn't exist
     i += 1 # increase the number
-  os.system("mkdir "+folder)  # create the temporal folder
+  #os.system("mkdir "+folder)  # create the temporal folder
+  pathlib.Path(folder).mkdir(parents=True, exist_ok=True) 
   os.chdir(folder)  # go to the temporal folder
   return folder  # return the name of the folder
 

--- a/pysrc/interpreter/pycommand.py
+++ b/pysrc/interpreter/pycommand.py
@@ -2,17 +2,19 @@ import subprocess
 import os
 import sys
 import platform
+from pathlib import Path
 
 
 def write_python_exec(name):
-    dirname = os.path.dirname(os.path.realpath(__file__)) # this directory
-    f = open(dirname+"/pythoninterpreter.py","w") # open file
-    f.write("mainpython = \""+name+"\"") # write this one
-    f.close() # close the file
+    """Create pythoninterpreter.py which contains the path to the target Python executable"""
+    os.environ["PYTHON_EXEC"] = name
+    path = Path('pythoninterpreter.py')
+    with open(path, mode='wt') as config:
+        config.write("mainpython = r\""+os.environ["PYTHON_EXEC"]+"\"")
 
 
 def correct_python(install=False):
-    """CHeck if a suitable Python is installed"""
+    """Check if a suitable Python is installed"""
     try:
         import PyQt5
         import scipy
@@ -20,100 +22,97 @@ def correct_python(install=False):
         import numba
         import matplotlib
         return True
-    except: 
-        if install: 
-            install_dependencies(executable=sys.executable) # try to install 
-            return correct_python(install=False) # try again
+    except:
+        if install:
+            install_dependencies(executable=sys.executable)  # try to install
+            return correct_python(install=False)  # try again
         return False
+
 
 def install_python():
     """Install a correct Python distribution"""
-    if correct_python(install=True): # The current one is the right Python 
-        write_python_exec(sys.executable) # write this Python distribution
+    if correct_python(install=True):  # The current one is the right Python
+        write_python_exec(sys.executable)  # write this Python distribution
         print("Found a correct python distribution")
-        return # nothing to do
-    pwd = os.getcwd() # get the current directory
-    dirname = os.path.dirname(os.path.realpath(__file__)) # this directory
-    os.system("rm -rf "+dirname+"/python_interpreter") # remove the subfolder
-    os.system("mkdir "+dirname+"/python_interpreter") # create the subfolder
-    os.chdir(dirname+"/python_interpreter") # go to this directory
-    pypath = dirname+"/python_interpreter/python3" # path to Python
-    if platform.system()=="Linux":
+        return  # nothing to do
+    dirname = os.path.dirname(os.path.realpath(__file__))  # this directory
+    os.system("rm -rf "+dirname+"/python_interpreter")  # remove the subfolder
+    os.system("mkdir "+dirname+"/python_interpreter")  # create the subfolder
+    os.chdir(dirname+"/python_interpreter")  # go to this directory
+    pypath = dirname+"/python_interpreter/python3"  # path to Python
+    if platform.system() == "Linux":
         anapath = "https://repo.anaconda.com/archive/Anaconda3-2020.02-Linux-x86_64.sh"
-        os.system("wget "+anapath) # download Anaconda Python
+        os.system("wget "+anapath)  # download Anaconda Python
         anafile = "Anaconda3-2020.02-Linux-x86_64.sh"
-    elif platform.system()=="Windows":
-        print("Not compatible with Windows yet")
+    elif platform.system() == "Windows":
+        print("Please download and install Anaconda")
         exit()
-    else: # for Mac
+    else:  # for Mac
         anapath = "https://repo.anaconda.com/archive/Anaconda3-2020.02-MacOSX-x86_64.sh"
-        os.system("curl -LO "+anapath) # download Anaconda Python
-        anafile = "Anaconda3-2020.02-MacOSX-x86_64.sh " # file to install
-    os.system("bash "+anafile+" -b -p "+pypath) # install anaconda
-    os.system("rm "+anafile) # remove the installer
+        os.system("curl -LO "+anapath)  # download Anaconda Python
+        anafile = "Anaconda3-2020.02-MacOSX-x86_64.sh "  # file to install
+    os.system("bash "+anafile+" -b -p "+pypath)  # install anaconda
+    os.system("rm "+anafile)  # remove the installer
     # now get the executable
-    dirname = os.path.dirname(os.path.realpath(__file__)) # this directory
-    pyint = dirname +"/python_interpreter/python3/bin/python3" # local one
-    write_python_exec(pyint) # write this Python distribution
-
+    dirname = os.path.dirname(os.path.realpath(__file__))  # this directory
+    pyint = dirname + "/python_interpreter/python3/bin/python3"  # local one
+    write_python_exec(pyint)  # write this Python distribution
 
 
 def install_dependencies(executable=None):
-    if executable is None: executable = get_python()
-    for l in ["mayavi","numba","scipy","numpy","matplotlib"]:
-        try: install_package(l,executable=executable)
-        except: pass
-    # try to compile fortran
-    try:
-        from ..pygra import compilefortran
-        compiler = os.path.dirname(os.path.realpath(get_python()))+"/f2py"
-        compilefortran.compile_fortran(compiler=compiler) # compile fortran
-    except: 
-        print("Fortran was not compiled")
-
+    if executable is None:
+        executable = get_python()
+    for l in ["mayavi", "numba", "scipy", "numpy", "matplotlib"]:
+        try:
+            install_package(l, executable=executable)
+        except:
+            pass
 
 
 def get_python():
-  """Return the path for Anaconda Python, which has pyqt by default"""
-  try:
-      #from .pythoninterpreter import mainpython
-      mainpython = sys.executable
-      return mainpython
-      print("Using the interpreter",mainpython)
-  except:
-      print("No python interpreter found, exiting")
-      exit()
+    """Return the path for Anaconda Python, which has pyqt by default"""
+    try:
+        #from .pythoninterpreter import mainpython
+        mainpython = sys.executable
+        #mainpython = os.environ["PYTHON_EXEC"]
+        print("Using the interpreter", mainpython)
+        return mainpython
+    except:
+        print("No python interpreter found, exiting")
+        exit()
 
 
 def add_to_path():
     """Add quantum honeycomp to the PATH"""
     out = os.environ["SHELL"]
     home = os.environ["HOME"]
-    if out=="/bin/bash":
-        if platform.system()=="Linux":  rcfile = home+"/.bashrc"
-        else: rcfile = home+"/.bash_profile"
-    elif out=="/bin/zsh": 
+    if out == "/bin/bash":
+        if platform.system() == "Linux":
+            rcfile = home+"/.bashrc"
+        else:
+            rcfile = home+"/.bash_profile"
+    elif out == "/bin/zsh":
         rcfile = home+"/.zshrc"
     qhpath = os.path.dirname(os.path.realpath(__file__))+"/../../bin"
-    try: ls = open(rcfile,"r").read() # if the file exists
-    except: ls = "" # otherwise
-    addrc = "alias quantum-honeycomp=\"" + get_python() +" "+qhpath+"/quantum-honeycomp\""
+    try:
+        ls = open(rcfile, "r").read()  # if the file exists
+    except:
+        ls = ""  # otherwise
+    addrc = "alias quantum-honeycomp=\"" + get_python() + " "+qhpath + \
+        "/quantum-honeycomp\""
 #    addrc = "\nexport PATH=\""+qhpath+"\":$PATH\n"
-    open(rcfile,"w").write(ls+addrc) # add to the bash
+    open(rcfile, "w").write(ls+addrc)  # add to the bash
 
 
-def install_package(package,executable=None):
-    if executable is None: executable = sys.executable
+def install_package(package, executable=None):
+    if executable is None:
+        executable = sys.executable
     subprocess.check_call([executable, "-m", "pip", "install", package])
-
 
 
 def run_qh():
     """Run Quantum Honeycomp"""
-    qhpath = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
-    qh = os.path.join(qhpath, "bin", "quantum-honeycomp.py")
-    os.system(sys.executable + " " + qh)
-
-
-
-
+    qhpath = Path(__file__).resolve().parent.parent.parent
+    qh = qhpath.joinpath('bin', "quantum-honeycomp.py")
+    subprocess.run(["python", str(qh)])
+    #os.system(get_python() + " " + qh)

--- a/pysrc/interpreter/pycommand.py
+++ b/pysrc/interpreter/pycommand.py
@@ -76,7 +76,8 @@ def install_dependencies(executable=None):
 def get_python():
   """Return the path for Anaconda Python, which has pyqt by default"""
   try:
-      from .pythoninterpreter import mainpython
+      #from .pythoninterpreter import mainpython
+      mainpython = sys.executable
       return mainpython
       print("Using the interpreter",mainpython)
   except:
@@ -109,9 +110,9 @@ def install_package(package,executable=None):
 
 def run_qh():
     """Run Quantum Honeycomp"""
-    qhpath = os.path.dirname(os.path.realpath(__file__))+"/../../bin"
-    os.system(get_python() +" "+qhpath+"/quantum-honeycomp &")
-
+    qhpath = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+    qh = os.path.join(qhpath, "bin", "quantum-honeycomp.py")
+    os.system(sys.executable + " " + qh)
 
 
 

--- a/pysrc/interpreter/pycommand.py
+++ b/pysrc/interpreter/pycommand.py
@@ -115,4 +115,3 @@ def run_qh():
     qhpath = Path(__file__).resolve().parent.parent.parent
     qh = qhpath.joinpath('bin', "quantum-honeycomp.py")
     subprocess.run(["python", str(qh)])
-    #os.system(get_python() + " " + qh)

--- a/pysrc/pygra/parallel.py
+++ b/pysrc/pygra/parallel.py
@@ -7,9 +7,9 @@ from . import algebra
 is_child = False # check if you are running a child
 
 try:
-  from multiprocess import Pool
-  import multiprocess
-  maxcpu = multiprocess.cpu_count()
+  from multiprocessing import Pool
+  import multiprocessing
+  maxcpu = multiprocessing.cpu_count()
 except:
     print("Multiprocess not working")
     def Pool(n=1): # workaround

--- a/utilities/plot3d
+++ b/utilities/plot3d
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 
-from mayavi import mlab as mlab
+from mayavi import mlab
 import numpy as np
 import sys
 
@@ -31,7 +31,6 @@ y = y/scale_y
 
 
 
-from mayavi import mlab
 mlab.figure(1, fgcolor=(0, 0, 0), bgcolor=(1, 1, 1))
 
 # Visualize the points

--- a/utilities/plot3d
+++ b/utilities/plot3d
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 
-import mayavi.mlab as mlab
+from mayavi import mlab as mlab
 import numpy as np
 import sys
 

--- a/utilities/qh-plot3d
+++ b/utilities/qh-plot3d
@@ -1,7 +1,7 @@
 #!/usr/bin/python2
 
 
-import mayavi.mlab as mlab
+from mayavi import mlab as mlab
 import numpy as np
 import sys
 

--- a/utilities/qh-plotchern
+++ b/utilities/qh-plotchern
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 
-import mayavi.mlab as mlab
+from mayavi import mlab as mlab
 import numpy as np
 import sys
 

--- a/utilities/tb90-plot3d
+++ b/utilities/tb90-plot3d
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 
-import mayavi.mlab as mlab
+from mayavi import mlab as mlab
 import numpy as np
 import sys
 

--- a/utilities/tb90-stm-fast
+++ b/utilities/tb90-stm-fast
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 
-import mayavi.mlab as mlab
+from mayavi import mlab as mlab
 import numpy as np
 import sys
 


### PR DESCRIPTION
This pull request is larger than than expected:
 - Some gitignore additions
 - Import errors related to: mayavi and multiprocessing
 - Initial implementation of pathlib on pycommand quantum-honeycomp.py
 - Rename quantum-honeycomp to quantum-honeycomp.py to allow for operation on Windows.
 - Change /tmp folder to tmp folder in the root directory of the program. /tmp does not exist on Windows machines and the data stored is small. 
 - Minor formatting changes (pep8 standard) on py-command and quantum-honeycomp.py. Improves readability of code.
 - Switch from os.system execution of python to subprocess execution (improves error checking to the function level).

The major feature is that this would allow for operation on Windows machines, once the user has already installed Anaconda with the appropriate libraries. There are still some errors with viewing 3D objects.

Tested with Windows and Ubuntu VM, but please check on Mac and your own Ubuntu VM to see if there is some unintended behavior.